### PR TITLE
Pass account_id to bptimer for multi-region support (needed by 12/18/25 for SEA/JPKR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="portada_v31.png" alt="BPSR Meter splash" width="820" />
 
-  # BPSR Meter (by gabrielsanbs) v3.2.6
+  # BPSR Meter (by gabrielsanbs) v3.2.7
 
 
 [![Release](https://img.shields.io/github/v/release/gabrielsanbs/BPSR-Meter?style=for-the-badge)](https://github.com/gabrielsanbs/BPSR-Meter/releases)
@@ -9,7 +9,7 @@
 
 Overlay de DPS para Blue Protocol.
 
-[**Download da Última Versão (v3.2.6)**](https://github.com/gabrielsanbs/BPSR-Meter/releases/latest)
+[**Download da Última Versão (v3.2.7)**](https://github.com/gabrielsanbs/BPSR-Meter/releases/latest)
 </div>
 
 ---

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,36 @@
+# 🎯 BPSR Meter v3.2.7
+
+[[Português](#português)] | [[English](#english)] | [[Español](#español)]
+
+---
+
+## Português
+
+**✨ NOVIDADES v3.2.7:**
+
+### 🛠️ BPTimer Patch (Suporte multi-região)
+Esta atualização adiciona suporte para envios multi-região no BPTimer para o lançamento SEA/JPKR de Blue Protocol: Star Resonance.
+
+---
+
+## English
+
+**✨ WHAT'S NEW v3.2.7:**
+
+### 🛠️ BPTimer Patch (Multi-region support)
+This update adds support for Multi-region submissions to BPTimer for the upcoming SEA/JPKR release of Blue Protocol: Star Resonance.
+
+---
+
+## Español
+
+**✨ NOVEDADES v3.2.7:**
+
+### 🛠️ BPTimer Parche (Soporte multirregión)
+Esta actualización agrega soporte para envíos multirregión en BPTimer para el próximo lanzamiento SEA/JPKR de Blue Protocol: Star Resonance.
+
+---
+
 # 🎯 BPSR Meter v3.2.6
 
 [[Português](#português)] | [[English](#english)] | [[Español](#español)]

--- a/algo/packet.js
+++ b/algo/packet.js
@@ -534,6 +534,10 @@ class PacketProcessor {
                 this.userDataManager.setName(playerUid, charBase.Name);
             }
 
+            if (charBase.AccountId) {
+                this.userDataManager.setAttrKV(playerUid, 'account_id', charBase.AccountId);
+            }
+
             if (charBase.FightPoint) this.userDataManager.setFightPoint(playerUid, charBase.FightPoint);
 
             if (vData.SceneData) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "bpsr-meter",
-  "version": "3.2.5",
+  "version": "3.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bpsr-meter",
-      "version": "3.2.5",
+      "version": "3.2.7",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@woheedev/bptimer-api-client": "^0.1.4",
+        "@woheedev/bptimer-api-client": "^0.2.0",
         "cap": "^0.2.1",
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
@@ -709,7 +709,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -731,7 +730,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -748,7 +746,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -763,7 +760,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -1282,6 +1278,7 @@
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -1358,9 +1355,9 @@
       }
     },
     "node_modules/@woheedev/bptimer-api-client": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@woheedev/bptimer-api-client/-/bptimer-api-client-0.1.4.tgz",
-      "integrity": "sha512-m/d6UyG8EigJFAitoe+AJRiCNaZ7DRWK7xvIhHJh1XMGfdqT85wn+CZWvjOzCguc5zXEz+AoqKFaMMp51rP1Lw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@woheedev/bptimer-api-client/-/bptimer-api-client-0.2.0.tgz",
+      "integrity": "sha512-IraoDAyZFYoJ3NWIPMBnQaxnKlXrJuUCA1FYEQupvQik8bXgOHnQgKGLl1kj0wRel3R4sSDrf0jj2e6VZby+JA==",
       "license": "AGPL-3.0-or-later"
     },
     "node_modules/@xmldom/xmldom": {
@@ -1455,6 +1452,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1515,6 +1513,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1943,23 +1942,43 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
+      "integrity": "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
         "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
+      "integrity": "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/boolean": {
@@ -2596,9 +2615,9 @@
       }
     },
     "node_modules/config-file-ts/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2718,8 +2737,7 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2927,6 +2945,7 @@
       "integrity": "sha512-59CAAjAhTaIMCN8y9kD573vDkxbs1uhDcrFLHSgutYdPcGOU35Rf95725snvzEOy4BFB7+eLJ8djCNPmGwG67w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.0.12",
         "builder-util": "26.0.11",
@@ -3300,7 +3319,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -3321,7 +3339,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -3351,17 +3368,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/end-of-stream": {
@@ -4442,6 +4448,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -4708,9 +4715,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5037,6 +5044,7 @@
       "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -5771,6 +5779,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5800,7 +5809,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -5818,7 +5826,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -5981,6 +5988,7 @@
       "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -7211,7 +7219,6 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -7275,7 +7282,6 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -7290,7 +7296,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.2.7",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@woheedev/bptimer-api-client": "^0.2.0",
+        "@woheedev/bptimer-api-client": "^0.2.2",
         "cap": "^0.2.1",
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
@@ -1355,9 +1355,9 @@
       }
     },
     "node_modules/@woheedev/bptimer-api-client": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@woheedev/bptimer-api-client/-/bptimer-api-client-0.2.0.tgz",
-      "integrity": "sha512-IraoDAyZFYoJ3NWIPMBnQaxnKlXrJuUCA1FYEQupvQik8bXgOHnQgKGLl1kj0wRel3R4sSDrf0jj2e6VZby+JA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@woheedev/bptimer-api-client/-/bptimer-api-client-0.2.2.tgz",
+      "integrity": "sha512-Pid6yp5N0gzz6GjC+lfnmovR7j31cnaW57uu+UzgxuXdPjEL7g/yfZ/HU7qHZQiKoFGrJy8dBUVZ4lrQzaQBcg==",
       "license": "AGPL-3.0-or-later"
     },
     "node_modules/@xmldom/xmldom": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "AGPL-3.0",
   "packageManager": "pnpm@10.13.1",
   "dependencies": {
-    "@woheedev/bptimer-api-client": "^0.2.0",
+    "@woheedev/bptimer-api-client": "^0.2.2",
     "cap": "^0.2.1",
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpsr-meter",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "description": "BPSR Meter",
   "main": "electron-main.js",
   "bin": {
@@ -24,7 +24,7 @@
   "license": "AGPL-3.0",
   "packageManager": "pnpm@10.13.1",
   "dependencies": {
-    "@woheedev/bptimer-api-client": "^0.1.4",
+    "@woheedev/bptimer-api-client": "^0.2.0",
     "cap": "^0.2.1",
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",

--- a/src/server/dataManager.js
+++ b/src/server/dataManager.js
@@ -1084,7 +1084,8 @@ class UserDataManager {
 
             // Obter account_id do jogador atual (para detecção de região)
             // O BPTimer usa isso para determinar automaticamente a região do servidor
-            const account_id = playerUid || this.currentPlayerUid;
+            const uid = playerUid || this.currentPlayerUid;
+            const account_id = this.getUser(uid)?.attr?.account_id;
 
             const sendReport = async () => {
                 this.pendingBPTimerReports.add(reportKey);
@@ -1105,6 +1106,11 @@ class UserDataManager {
                     // Adicionar account_id se disponível (para detecção de região)
                     if (account_id) {
                         reportParams.account_id = account_id;
+                    }
+
+                    // Adicionar uid se disponível (para vincular usuários à conta do site)
+                    if (uid) {
+                        reportParams.uid = uid;
                     }
 
                     const result = await this.bpTimerClient.reportHP(reportParams);


### PR DESCRIPTION
Changes:

feat: fix account_id handling and pass along with uid to bptimer
chore: update bptimer-api-client to 0.2.0
chore: patch version for release